### PR TITLE
Correct name of SheetMetal Workbench

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -27,7 +27,7 @@
 <depend>Part</depend>
 <depend>Draft</depend>
 <depend>Sketcher</depend>
-<depend>sheetmetal</depend>
+<depend>SheetMetal Workbench</depend>
 <depend>olefile</depend>
 <depend>xlrd</depend>
 <depend>xlwt</depend>


### PR DESCRIPTION
In order for the Addon Manager to correctly resolve dependencies, your `<depend>` lines must exactly match the canonical name of the WB -- in this case, `SheetMetal Workbench` is what that WB calls itself in its own package.xml file.